### PR TITLE
Bugfix/case insensitive searches

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -93,7 +93,9 @@ function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
     console.log('term: ', term);
-    accordion.collapse(term.elm.firstChild);
+    const termElm = term.elm.firstChild;
+    const content = document.getElementById(termElm.getAttribute('aria-controls'));
+    if(content) accordion.collapse(term.elm.firstChild);
   })
 }
 

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -92,6 +92,7 @@ function getTabIndex(elm) {
 function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
+    console.log('term: ', term);
     accordion.collapse(term.elm.firstChild);
   })
 }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -92,7 +92,6 @@ function getTabIndex(elm) {
 function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
-    console.log('term: ', term);
     const termElm = term.elm.firstChild;
     const content = document.getElementById(termElm.getAttribute('aria-controls'));
     if(content) accordion.collapse(term.elm.firstChild);

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -209,7 +209,7 @@ Glossary.prototype.findTerm = function(term) {
     },
   );
   this.list.filter(function(item) {
-    return item._values['data-glossary-term'].toLowerCase() === term;
+    return item._values['data-glossary-term'].toLowerCase() === term.toLowerCase();
   });
 
   this.list.search();

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -176,7 +176,7 @@ Glossary.prototype.linkTerms = function() {
     term.setAttribute('tabIndex', 0);
     term.setAttribute(
       'data-term',
-      (term.getAttribute('data-term') || '').toLowerCase(),
+      (term.getAttribute('data-term') || ''),
     );
   });
   document.body.addEventListener('click', this.handleTermTouch.bind(this));

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -92,6 +92,7 @@ function getTabIndex(elm) {
 function collapseTerms(accordion, list) {
   // collapse any visible terms
   list.visibleItems.forEach((term) => {
+    // Collapse the term if it is on the DOM
     const termElm = term.elm.firstChild;
     const content = document.getElementById(termElm.getAttribute('aria-controls'));
     if(content) accordion.collapse(term.elm.firstChild);


### PR DESCRIPTION
This pull request makes it so that terms no longer need to be lower case and they will show up in the search box exactly how they are typed (the searches are still case insensitive). This PR also fixes an issue where console errors would sometimes occur if a user clicked on a term while the glossary was open.