### PR TITLE
feature/clickable toggle button icons

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -298,7 +298,7 @@ Glossary.prototype.handleKeyup = function(e) {
 // Close glossary when clicking outside of glossary
 Glossary.prototype.closeOpenGlossary = function(e) {
   if (
-    e.target !== this.toggleBtn &&
+    (e.target !== this.toggleBtn && e.target.parentElement !== this.toggleBtn) &&
     !e.target.getAttribute('data-term') &&
     this.isOpen
   ) {


### PR DESCRIPTION
Issue: Clicking the book icon in the HMW Glossary toggle button does not open the Glossary.

This branch adds a check to see if the parent element of the clicked target is the toggle button, which allows `<i>` tags in the toggle button to function normally, as well as any other tag that is inserted into the button. 

Ticket: https://app.breeze.pm/projects/100762/cards/3161046