### PR TITLE
Enhance/remove search on close

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -260,7 +260,12 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  this.findTerm('');
+  forEach(
+    this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
+    function (term) {
+      term.style = 'display: list-item;'
+    }
+  );
   
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -304,8 +304,8 @@ Glossary.prototype.handleInput = function() {
       function (term) {
         term.style = 'display: list-item;'
       }
-    );
-  } */
+    );*/
+  } 
 
   collapseTerms(this.accordion, this.list);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -101,6 +101,18 @@ function collapseTerms(accordion, list) {
   })
 }
 
+/** Shows or hides all terms */
+function showHideAllTerms(show) {
+  let display = show ? 'display: list-item;' : 'display: none;';
+
+  forEach(
+    this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
+    function (term) {
+      term.style = display +
+    }
+  )
+}
+
 /**
  * Glossary widget
  * @constructor
@@ -219,12 +231,13 @@ Glossary.prototype.findTerm = function(term) {
   const lowerCaseTerm = term.toLowerCase();
 
   // hide all terms
-  forEach(
+  showHideAllTerms(false);
+  /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: none;'
     }
-  );
+  ); */
 
   // show terms that match the search criteria and store the first term that was found
   let firstTerm = null;
@@ -260,12 +273,13 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  forEach(
+  showHideAllTerms();
+  /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: list-item;'
     }
-  );
+  ); */
   
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
@@ -284,13 +298,14 @@ Glossary.prototype.handleInput = function() {
   }
   else {
     // display everything since the search field is empty
-    forEach(
+    showHideAllTerms(true);
+    /* forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {
         term.style = 'display: list-item;'
       }
     );
-  }
+  } */
 
   collapseTerms(this.accordion, this.list);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,16 +258,16 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  // remove the search criteria
+  this.search.value = '';
+  this.findTerm('');
+  
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
-
-  // remove the search criteria
-  this.search.value = '';
-  this.findTerm('');
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -102,15 +102,15 @@ function collapseTerms(accordion, list) {
 }
 
 /** Shows or hides all terms */
-function showHideAllTerms(show) {
-  let display = show ? 'display: list-item;' : 'display: none;';
+function showHideAllTerms(show, className) {
+  const cssValue = show ? 'display: list-item;' : 'display: none;';
 
   forEach(
-    this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
+    this.body.querySelectorAll('li[class*="' + className + '"]'),
     function (term) {
-      term.style = display;
+      term.style = cssValue;
     }
-  )
+  );
 }
 
 /**
@@ -231,7 +231,7 @@ Glossary.prototype.findTerm = function(term) {
   const lowerCaseTerm = term.toLowerCase();
 
   // hide all terms
-  showHideAllTerms(false);
+  showHideAllTerms(false, this.classes.glossaryItemClass);
   /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
@@ -273,7 +273,7 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  showHideAllTerms();
+  showHideAllTerms(true, this.classes.glossaryItemClass);
   /* forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
@@ -298,7 +298,7 @@ Glossary.prototype.handleInput = function() {
   }
   else {
     // display everything since the search field is empty
-    showHideAllTerms(true);
+    showHideAllTerms(true, this.classes.glossaryItemClass);
     /* forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -101,18 +101,6 @@ function collapseTerms(accordion, list) {
   })
 }
 
-/** Shows or hides all terms */
-function showHideAllTerms(show, className) {
-  const cssValue = show ? 'display: list-item;' : 'display: none;';
-
-  forEach(
-    this.body.querySelectorAll('li[class*="' + className + '"]'),
-    function (term) {
-      term.style = cssValue;
-    }
-  );
-}
-
 /**
  * Glossary widget
  * @constructor
@@ -231,13 +219,12 @@ Glossary.prototype.findTerm = function(term) {
   const lowerCaseTerm = term.toLowerCase();
 
   // hide all terms
-  showHideAllTerms(false, this.classes.glossaryItemClass);
-  /* forEach(
+  forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: none;'
     }
-  ); */
+  );
 
   // show terms that match the search criteria and store the first term that was found
   let firstTerm = null;
@@ -273,13 +260,12 @@ Glossary.prototype.show = function() {
 Glossary.prototype.hide = function() {
   // remove the search criteria
   this.search.value = '';
-  showHideAllTerms(true, this.classes.glossaryItemClass);
-  /* forEach(
+  forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
       term.style = 'display: list-item;'
     }
-  ); */
+  );
   
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
@@ -298,14 +284,13 @@ Glossary.prototype.handleInput = function() {
   }
   else {
     // display everything since the search field is empty
-    showHideAllTerms(true, this.classes.glossaryItemClass);
-    /* forEach(
+    forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {
         term.style = 'display: list-item;'
       }
-    );*/
-  } 
+    );
+  }
 
   collapseTerms(this.accordion, this.list);
 };

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,6 +258,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  this.search.value = '';
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -258,13 +258,16 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  this.search.value = '';
   this.body.setAttribute('aria-hidden', 'true');
   this.toggleBtn.setAttribute('aria-expanded', 'false');
   this.selectedTerm.focus();
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
+
+  // remove the search criteria
+  this.search.value = '';
+  this.findTerm('');
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -108,7 +108,7 @@ function showHideAllTerms(show) {
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
-      term.style = display +
+      term.style = display;
     }
   )
 }


### PR DESCRIPTION
This makes it so closing the glossary removes any filters. Then when the user opens the glossary again all of the terms will be visible.