### PR TITLE
bugfix/unable to close glossary panel

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -262,7 +262,9 @@ Glossary.prototype.hide = function() {
   this.body.scrollTo(0, 0);
 
   // remove the search criteria
-  this.search.value = '';
+  if (this.search){
+    this.search.value = '';
+  } 
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {


### PR DESCRIPTION
Ticket: https://app.breeze.pm/projects/100762/cards/3163197

Didn't think to test this with our latest changes. Adds a check to see if search box exists before setting the value. Prevents issues when the error message is displayed instead of the terms and search box.