### PR TITLE
Bugfix/old ios safari bugs

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -144,6 +144,7 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
   this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'touchstart', this.closeOpenGlossary.bind(this));
 }
 
 /** Clears terms from the glossary list to ensure no duplication. */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -271,6 +271,7 @@ Glossary.prototype.show = function() {
 
 Glossary.prototype.hide = function() {
   //scroll to the top - handle older browsers where .scrollTo is not supported
+  alert("in hide function")
   try{
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -271,6 +271,7 @@ Glossary.prototype.show = function() {
 
 Glossary.prototype.hide = function() {
   //scroll to the top - handle older browsers where .scrollTo is not supported
+  try{
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
 
@@ -292,6 +293,10 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
+  }
+  catch(e){
+    alert(e)
+  }
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -270,8 +270,9 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  //scroll to the top
-  this.body.scrollTo(0, 0);
+  //scroll to the top - handle older browsers where .scrollTo is not supported
+  const scrollingElement = document.scrollingElement || document.documentElement;
+  scrollingElement.scrollTop = 0;
 
   // remove the search criteria
   if (this.search){
@@ -280,7 +281,8 @@ Glossary.prototype.hide = function() {
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
-      term.style = 'display: list-item;'
+      // handle older browsers where .style is readonly
+      term.style.cssText = 'display: list-item;'
     }
   );
   

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -143,8 +143,7 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
-  this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
-  this.addEventListener(document, 'touchstart', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'click touchstart', this.closeOpenGlossary.bind(this));
 }
 
 /** Clears terms from the glossary list to ensure no duplication. */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -143,7 +143,8 @@ function Glossary(terms, selectors, classes) {
   this.addEventListener(this.closeBtn, 'click', this.hide.bind(this));
   this.addEventListener(this.search, 'input', this.handleInput.bind(this));
   this.addEventListener(document.body, 'keyup', this.handleKeyup.bind(this));
-  this.addEventListener(document, 'click touchstart', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'click', this.closeOpenGlossary.bind(this));
+  this.addEventListener(document, 'touchstart', this.closeOpenGlossary.bind(this)); // for iPads 
 }
 
 /** Clears terms from the glossary list to ensure no duplication. */
@@ -270,9 +271,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  //scroll to the top - handle older browsers where .scrollTo is not supported
-  alert("in hide function")
-  try{
+  //scroll to the top: handle older browsers where .scrollTo is not supported
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
 
@@ -294,10 +293,6 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
-  }
-  catch(e){
-    alert(e)
-  }
 };
 
 /** Remove existing filters on input */
@@ -336,7 +331,6 @@ Glossary.prototype.closeOpenGlossary = function(e) {
     !e.target.getAttribute('data-term') &&
     this.isOpen
   ) {
-    alert('in closeopenglossary!')
     if (!closest(e.target, this.selectors.glossaryID)) {
       this.hide();
     }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -336,6 +336,7 @@ Glossary.prototype.closeOpenGlossary = function(e) {
     !e.target.getAttribute('data-term') &&
     this.isOpen
   ) {
+    alert('in closeopenglossary!')
     if (!closest(e.target, this.selectors.glossaryID)) {
       this.hide();
     }


### PR DESCRIPTION
**Ticket:** https://app.breeze.pm/projects/100762/cards/3442549

**Main changes:**
To support older browsers and devices (like iPads) 
-  added an event listener for `touchstart` which is fired on touch events on older iPads.
- because `element.scrollTo()` is not supported in older browsers I've switched to a more widely supported function that does the same thing. 
- changed `element.style =` to `element.style.csstext =` because in older versions of iOS Safari the `style` attribute is readonly.

**Steps to test:**
1. In the HMW client folder's package.json, change this line:
`"glossary-panel": "github:Eastern-Research-Group/glossary"`
to
`"glossary-panel": "github:Eastern-Research-Group/glossary#bugfix/old-ios-safari-bugs"`

2. Run `npm install` in the client folder.
3. Run the app locally. Verify the glossary works as it should.
4. To test on an older iPad, I used the Browserstack to test my localhost:3000 on Browserstack's iPad Mini 4 - iOS 9.3
![image](https://user-images.githubusercontent.com/17204883/88969440-e224db80-d27e-11ea-8525-cc8aeb1019e1.png)
![image](https://user-images.githubusercontent.com/17204883/88969663-2d3eee80-d27f-11ea-9672-95adf284fe04.png)
5. Verify that touch events correctly open and close the glossary popup. 


