### PR TITLE
Bugfix/safari 9 issues

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -236,7 +236,7 @@ Glossary.prototype.findTerm = function(term) {
   forEach(
     this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
     function (term) {
-      term.style = 'display: none;'
+      term.style.cssText = 'display: none;'
     }
   );
 
@@ -245,7 +245,7 @@ Glossary.prototype.findTerm = function(term) {
   forEach(
     this.body.querySelectorAll('li[data-glossary-term-value*="' + lowerCaseTerm + '"]'),
     function (term) {
-      term.style = 'display: list-item;'
+      term.style.cssText = 'display: list-item;'
       if(!firstTerm) firstTerm = term;
     }
   );
@@ -317,7 +317,7 @@ Glossary.prototype.handleInput = function() {
     forEach(
       this.body.querySelectorAll('li[class*="' + this.classes.glossaryItemClass + '"]'),
       function (term) {
-        term.style = 'display: list-item;'
+        term.style.cssText = 'display: list-item;'
       }
     );
   }

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -276,6 +276,7 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  try{
   //scroll to the top: handle older browsers where .scrollTo is not supported
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
@@ -298,6 +299,10 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
+  }
+  catch(e){
+    alert(e)
+  }
 };
 
 /** Remove existing filters on input */

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -212,6 +212,7 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
+  try{
   // skip find term if the search box is not on the DOM
   if(!this.search) return ;
 
@@ -256,6 +257,10 @@ Glossary.prototype.findTerm = function(term) {
     var button = firstTerm.querySelector('button');
     this.accordion.expand(button);
   }
+}
+catch(e){
+  alert(e)
+}
 };
 
 Glossary.prototype.toggle = function() {

--- a/src/glossary.js
+++ b/src/glossary.js
@@ -212,7 +212,6 @@ Glossary.prototype.handleTermTouch = function(e) {
 
 /** Highlight a term */
 Glossary.prototype.findTerm = function(term) {
-  try{
   // skip find term if the search box is not on the DOM
   if(!this.search) return ;
 
@@ -257,10 +256,6 @@ Glossary.prototype.findTerm = function(term) {
     var button = firstTerm.querySelector('button');
     this.accordion.expand(button);
   }
-}
-catch(e){
-  alert(e)
-}
 };
 
 Glossary.prototype.toggle = function() {
@@ -276,7 +271,6 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  try{
   //scroll to the top: handle older browsers where .scrollTo is not supported
   const scrollingElement = document.scrollingElement || document.documentElement;
   scrollingElement.scrollTop = 0;
@@ -299,10 +293,6 @@ Glossary.prototype.hide = function() {
   collapseTerms(this.accordion, this.list);
   this.isOpen = false;
   removeTabindex(this.body);
-  }
-  catch(e){
-    alert(e)
-  }
 };
 
 /** Remove existing filters on input */


### PR DESCRIPTION
**Ticket:** https://app.breeze.pm/projects/100762/cards/3442549 (this ticket is related to recent ticket comments)

**Main changes:**
Safari 9 and below treats `element.style` as a read-only attribute. Changed all usage of `element.style` to `element.style.cssText` to get around this issue

**Steps to test:**
1. In the HMW client folder's package.json, change this line:
`"glossary-panel": "github:Eastern-Research-Group/glossary"`
to
`"glossary-panel": "github:Eastern-Research-Group/glossary#bugfix/safari-9-issues"`

2. Run `npm install` in the client folder.
3. Run the app locally. Verify the glossary works as it should.
4. To test on an older iPad, I used the Browserstack to test my localhost:3000 on Browserstack's iPad Mini 4 - iOS 9.3
![image](https://user-images.githubusercontent.com/17204883/88969440-e224db80-d27e-11ea-8525-cc8aeb1019e1.png)
![image](https://user-images.githubusercontent.com/17204883/88969663-2d3eee80-d27f-11ea-9672-95adf284fe04.png)
5. Verify that touch events correctly open and close the glossary popup. 
6. Search a location on the Community tab.
7. Click a glossary term and verify that the Glossary panel opens and displays the term you clicked.
Note: Arcgis 4.x does not appear to be supported in older browsers like Safari 9 so the map won't show on this emulator, more info in the Breeze ticket above. 