### PR TITLE
bugfix/scrolling-issue

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -296,10 +296,6 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
-  //scroll to the top: handle older browsers where .scrollTo is not supported
-  const scrollingElement = document.scrollingElement || document.documentElement;
-  scrollingElement.scrollTop = 0;
-
   // remove the search criteria
   if (this.search){
     this.search.value = '';


### PR DESCRIPTION
Ticket: https://app.breeze.pm/projects/100762/cards/3801531

Removes code that causes the page to scroll to the top after closing the glossary panel.

Steps to reproduce
- Navigate to https://mywaterway-dev.app.cloud.gov/community/dc/overview
- Enter the full screen map by clicking the Full Screen button in the bottom right-hand corner of the map.
- Select a waterbody on the map until you find one that has at least 1 Impairment Category.
- Click on the Glossary link for the Impairment Category to open the Glossary.
- Close the Glossary by clicking outside of the Glossary panel or click the X in the top right corner of the Glossary.
- The screen should scroll up revealing the page header and leaving you unable to leave full screen mode.