### PR TITLE
Bugfix/re-add panel scrolling

### DIFF
--- a/src/glossary.js
+++ b/src/glossary.js
@@ -296,6 +296,9 @@ Glossary.prototype.show = function() {
 };
 
 Glossary.prototype.hide = function() {
+  //scroll Glossary panel to the top - handle older browsers where .scrollTo is not supported
+  this.body.scrollTop = 0;
+
   // remove the search criteria
   if (this.search){
     this.search.value = '';


### PR DESCRIPTION
Ticket: https://app.breeze.pm/projects/100762/cards/3801531

My last PR removed the scrolling behavior because it caused the HMW Full Screen map to break. This was because in July 2020 I modified the scrolling code to support older browsers https://github.com/Eastern-Research-Group/glossary/pull/14/files. In doing so I broke the feature so it scrolled the entire page up instead of just the glossary. In this PR I am re-adding the scroll behavior while supporting older browsers and not affecting the HMW map.